### PR TITLE
Add an option to squash all messages into one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add git curl jq bash grep sed
+RUN apk --no-cache add git curl jq bash grep
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The details of the new commit message
 Some other text not related to the commit message in particular.
 ````
 
+There is also an option to concatenate all messages like GitHub's "Squash and merge" feature.
+
+```
+/softfix:squash
+```
+
 ## Motivation
 A PR should be atomic in itself, and can usually be a single commit. When you submit a change to an upstream repo, after a long and arduous review process, you will probably be asked to "squash" your commits. This can be confusing, especially for new contributors, so this action makes it easy to turn the entire changeset into one commit and if one wants to do so, change the commit message.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,15 +3,7 @@
 set -e
 
 PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
-COMMENT_BODY=$(jq ".comment.body" "$GITHUB_EVENT_PATH")
-
-ESCAPED_COMMIT_MSG=$(echo $COMMENT_BODY | sed -e 's=.*/softfix\\r\\n```\(.*\)\\r\\n```.*=\1=')
-COMMIT_MSG=$(echo -e $ESCAPED_COMMIT_MSG)
-
-if [[ "$ESCAPED_COMMIT_MSG" == "$COMMENT_BODY" ]]; then
-	# Do not edit the commit message
-	COMMIT_MSG=""
-fi
+COMMENT_BODY=$(jq -r '.comment.body | gsub("\r\n"; "\n")' "$GITHUB_EVENT_PATH")
 
 # Grab the old commit message and use it if there is nothing else
 # But really only handling of the message is required now, and a lot of cleanup
@@ -33,6 +25,9 @@ COMMITS_URL=$(echo "$pr_response" | jq -r .commits_url)
 commits_response=$(curl -s -H "${AUTH_HEADER}" -H "${API_HEADER}" $COMMITS_URL)
 # This is limited to 250 entries, but it should be okay
 N_COMMITS=$(echo $commits_response | jq -r length)
+
+# /softfix ``` ... ```
+COMMIT_MSG=$(jq -rRs 'match("(?<!\\S)/softfix\\n```\\n(.*?)\\n```(?:\\n|\\z)"; "m").captures[0].string' <<<"$COMMENT_BODY")
 
 if [[ -z "$COMMIT_MSG" ]] && [[ "$N_COMMITS" -eq 1 ]]; then
 	echo "Nothing to do here, aborting..."
@@ -70,6 +65,12 @@ git remote add fork https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REP
 git fetch fork $HEAD_BRANCH
 
 git checkout -b $HEAD_BRANCH fork/$HEAD_BRANCH
+
+if [[ -z "$COMMIT_MSG" ]] && jq -eRs 'test("(?<!\\S)/softfix:squash\\b")' <<<"$COMMENT_BODY" >/dev/null; then
+	# /softfix:squash: GitHub's Squash and merge style
+	COMMIT_MSG=$(git log --reverse --pretty=format:"* %B" "HEAD~$N_COMMITS..HEAD" | tail -c +3)
+fi
+
 git reset --soft HEAD~$(($N_COMMITS-1))
 
 if [[ -z "$COMMIT_MSG" ]]; then
@@ -79,10 +80,3 @@ else
 fi
 
 git push --force-with-lease fork $HEAD_BRANCH
-
-
-
-
-
-
-


### PR DESCRIPTION
This is how a message is composed in "squash" whereas the default behavior is like "fixup", so I named it `/softfix:squash`.

The delimiter is double newline + `* `, which is styled after GitHub's "Squash and merge" option.